### PR TITLE
chore: .gitignore 에 .idea/, *.iml 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+.idea/
+*.iml
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml


### PR DESCRIPTION
## 작업내용 
- .gitignore에 idea/, *.iml추가 
- dev 브랜치에서 자동 생성되는 파일때문에 git pull origin dev 안되는 상황때문에 추가합니다. 

## 기타 사항
없음. 